### PR TITLE
[Feat] 예외 처리 공통 로직 작성

### DIFF
--- a/ticketing-kiwi/src/main/java/study/kiwi/ticketing_kiwi/domain/test/TestController.java
+++ b/ticketing-kiwi/src/main/java/study/kiwi/ticketing_kiwi/domain/test/TestController.java
@@ -1,0 +1,21 @@
+package study.kiwi.ticketing_kiwi.domain.test;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import study.kiwi.ticketing_kiwi.global.exception.CommonException;
+import study.kiwi.ticketing_kiwi.global.exception.CommonResponseStatus;
+
+@Slf4j
+@RestController
+public class TestController {
+
+    @RequestMapping("/test-member-v1/{name}")
+    public TestMember testExceptionHandler(@PathVariable("name") String name) {
+        log.info("TestController :: testExceptionHandler :: name = {}", name);
+        if ("ex".equals(name))
+            throw new CommonException(CommonResponseStatus.BAD_REQUEST);
+        return (new TestMember(name, 20));
+    }
+}

--- a/ticketing-kiwi/src/main/java/study/kiwi/ticketing_kiwi/domain/test/TestMember.java
+++ b/ticketing-kiwi/src/main/java/study/kiwi/ticketing_kiwi/domain/test/TestMember.java
@@ -1,0 +1,14 @@
+package study.kiwi.ticketing_kiwi.domain.test;
+
+import lombok.Getter;
+
+@Getter
+public class TestMember {
+    private String name;
+    private int age;
+
+    TestMember(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+}

--- a/ticketing-kiwi/src/main/java/study/kiwi/ticketing_kiwi/global/exception/CommonException.java
+++ b/ticketing-kiwi/src/main/java/study/kiwi/ticketing_kiwi/global/exception/CommonException.java
@@ -1,0 +1,14 @@
+package study.kiwi.ticketing_kiwi.global.exception;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class CommonException extends RuntimeException {
+    private CommonResponseStatus error;
+
+    public CommonException(CommonResponseStatus error) {
+        super(error.getMessage());
+        this.error = error;
+    }
+}

--- a/ticketing-kiwi/src/main/java/study/kiwi/ticketing_kiwi/global/exception/CommonResponseStatus.java
+++ b/ticketing-kiwi/src/main/java/study/kiwi/ticketing_kiwi/global/exception/CommonResponseStatus.java
@@ -1,0 +1,33 @@
+package study.kiwi.ticketing_kiwi.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum CommonResponseStatus {
+
+    /**
+     * 성공 반환 2000번대
+     */
+    SUCCESS(2000, "요청에 성공하였습니다.", HttpStatus.OK),
+
+    /**
+     * 클라이언트 에러 4000번대
+     */
+    BAD_REQUEST(4000, "클라이언트의 잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
+
+    /**
+     * 서버 에러 5000번대
+     */
+    INTERNAL_SERVER_ERROR(5000, "서버에서 알 수 없는 에러가 발생하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final int code;
+    private final String message;
+    private final HttpStatus statusCode;
+
+    CommonResponseStatus(int code, String message, HttpStatus statusCode) {
+        this.code = code;
+        this.message = message;
+        this.statusCode = statusCode;
+    }
+}

--- a/ticketing-kiwi/src/main/java/study/kiwi/ticketing_kiwi/global/exception/ErrorWrapper.java
+++ b/ticketing-kiwi/src/main/java/study/kiwi/ticketing_kiwi/global/exception/ErrorWrapper.java
@@ -1,0 +1,12 @@
+package study.kiwi.ticketing_kiwi.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorWrapper<T> {
+    private final T error;
+
+    public ErrorWrapper(T error) {
+        this.error = error;
+    }
+}

--- a/ticketing-kiwi/src/main/java/study/kiwi/ticketing_kiwi/global/exception/errorResponse/DefaultErrorResponse.java
+++ b/ticketing-kiwi/src/main/java/study/kiwi/ticketing_kiwi/global/exception/errorResponse/DefaultErrorResponse.java
@@ -1,0 +1,14 @@
+package study.kiwi.ticketing_kiwi.global.exception.errorResponse;
+
+import lombok.Getter;
+
+@Getter
+public class DefaultErrorResponse {
+    private final int code;
+    private final String message;
+
+    public DefaultErrorResponse(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/ticketing-kiwi/src/main/java/study/kiwi/ticketing_kiwi/global/exception/exceptionHandler/DefaultExceptionHandler.java
+++ b/ticketing-kiwi/src/main/java/study/kiwi/ticketing_kiwi/global/exception/exceptionHandler/DefaultExceptionHandler.java
@@ -1,0 +1,19 @@
+package study.kiwi.ticketing_kiwi.global.exception.exceptionHandler;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import study.kiwi.ticketing_kiwi.global.exception.CommonException;
+import study.kiwi.ticketing_kiwi.global.exception.ErrorWrapper;
+import study.kiwi.ticketing_kiwi.global.exception.errorResponse.DefaultErrorResponse;
+
+@RestControllerAdvice("study.kiwi.ticketing_kiwi.domain")
+public class DefaultExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorWrapper<DefaultErrorResponse>> commonExHandle(CommonException e) {
+        DefaultErrorResponse errorReport = new DefaultErrorResponse(e.getError().getCode(), e.getMessage());
+        ErrorWrapper<DefaultErrorResponse> error = new ErrorWrapper<>(errorReport);
+        return new ResponseEntity<>(error, e.getError().getStatusCode());
+    }
+}


### PR DESCRIPTION
## 📌설명

클라이언트측에 응답 반환 시 성공적인 응답과 에러/예외 발생 시의 응답을 공통적으로 처리할 필요가 있음.

## 📌작업 내용
- 성공적인 응답 반환 시 반환하여야 할 객체 자체를 반환하는 것으로 결정.
  - 객체를 "data" 필드로 감싸서 반환을 해야한다고 판단되면 Wrapper 추가 예정.
- 에러/예외 발생 시 에러의 코드, 메시지를 반환.
  - 에러를 반환할 때에는 아래 예시와 같이 "error" 필도 한번 감싸서 반환시킴.
    ```
      {
         "error" : {
             "code" : 4000,
             "message" : "Client Request Error"
          }
      }
    ```

## 📌Issue
this closes #1 
